### PR TITLE
Fix update-loop bugs, harden downloads, and add test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,28 @@ A simple to use tool to help you save time by updating all your minecraft mods (
 Mainly to be used for server mod management.
 
 # How to use
-1. Install the mod-updater.py file.
-2. Execute it through your terminal with `python mod-updater.py -p {MINECRAFT_FOLDER_PATH} {MCVERSION}`, using -p is not necessary if the script is already located in the .minecraft folder.
-3. It should then automatically check each mod and install their respected loader version updates from Modrinth.
+1. Clone or download this repository.
+2. Install the dependencies with `pip install -r requirements.txt`.
+3. Run the script through your terminal:
+
+   ```
+   python main.py <MCVERSION> <MINECRAFT_FOLDER_PATH>
+   ```
+
+   For example: `python main.py 1.21 ~/.minecraft`
+
+4. It then checks each `.jar` file in the `mods` folder and installs the latest compatible version for your game version and mod loader from Modrinth.
+
+## Options
+| Flag | Description |
+| --- | --- |
+| `-k`, `--keep` | Keep outdated mod files instead of deleting them |
+| `--log-dir DIR` | Directory to store logs in (default: `./log`) |
+| `--log-level LEVEL` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (default: `INFO`) |
+| `-V`, `--version` | Show the script version |
+
+# Running the tests
+```
+pip install pytest
+pytest
+```

--- a/apis/__init__.py
+++ b/apis/__init__.py
@@ -1,9 +1,9 @@
 __version__ = '1.4.0'
-__all__ = ['base', 'modrinth_api']
+__all__ = ['base', 'modrinth_api', 'BaseModApiClient']
 
 import logging
 
-logger = logging.getLogger('root')
+logger = logging.getLogger(__name__)
 
 USER_AGENT = f'Solhex/mc-mod-helper/{__version__} (contact@solfvern.com)'
 logger.debug(f'User agent: {USER_AGENT}')

--- a/apis/base.py
+++ b/apis/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 from abc import ABC
@@ -7,7 +9,7 @@ from requests.exceptions import HTTPError, ConnectionError, Timeout
 
 from . import HEADERS
 
-logger = logging.getLogger('root')
+logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 15
 
@@ -39,12 +41,12 @@ class BaseModApiClient(ABC):
         :type base_url: str
         :param headers: Optional request headers.
         :type headers: dict | None
-        :raises Exception: If base_url is not a valid HTTP or HTTPS URL.
+        :raises ValueError: If base_url is not a valid HTTP or HTTPS URL.
         """
 
         url_pattern = r'^(https?://)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,}'
         if not re.match(url_pattern, base_url):
-            raise Exception(f'Invalid URL: {base_url}')
+            raise ValueError(f'Invalid URL: {base_url}')
 
         self.base_url = base_url if base_url[-1] == '/' else base_url + '/'
         self.headers = headers if headers is not None else HEADERS
@@ -75,8 +77,10 @@ class BaseModApiClient(ABC):
             method = method[1:]
         kwargs.setdefault('timeout', DEFAULT_TIMEOUT)
         try:
+            # base_url is normalized to always end with a slash,
+            # so plain concatenation avoids a double slash.
             response = self._session.post(
-                '/'.join((self.base_url, method)),
+                self.base_url + method,
                 json=body,
                 headers=self.headers,
                 **kwargs)
@@ -95,7 +99,7 @@ class BaseModApiClient(ABC):
             return {'error': 'Failed to retrieve data. See log for more details.'}
 
         logger.info(f'Request: {response.request.method} {response.request.url} - '
-                     f'Status: {response.status_code}')
+                    f'Status: {response.status_code}')
         logger.debug(f'Request headers: {response.request.headers}')
         logger.debug(f'Request body: {response.request.body}')
         logger.debug(f'Request content: {response.text}')

--- a/apis/modrinth_api.py
+++ b/apis/modrinth_api.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 __version__ = '1.1.3'
 
 import logging
 from .base import BaseModApiClient
 
-logger = logging.getLogger('root')
+logger = logging.getLogger(__name__)
 
 MODRINTH_API_URL = 'https://api.modrinth.com/v2'
 logger.debug(f'Modrinth API URL: {MODRINTH_API_URL}')
+
 
 class ModrinthAPI(BaseModApiClient):
     """Client for retrieving mod information from the Modrinth API."""
@@ -46,7 +49,7 @@ class ModrinthAPI(BaseModApiClient):
             may return empty dictionary if an error occurs
         :rtype: dict
         """
-        logger.info(f'Starting get_mods_by_hash')
+        logger.info('Starting get_mods_by_hash')
         body = {
             'hashes': mod_hash_list,
             'algorithm': self.hash_type
@@ -75,7 +78,7 @@ class ModrinthAPI(BaseModApiClient):
             may return empty dictionary if an error occurs
         :rtype: dict
         """
-        logger.info(f'Starting get_mod_updates_by_hash')
+        logger.info('Starting get_mod_updates_by_hash')
         body = {
             'hashes': mod_hash_list,
             'algorithm': self.hash_type,

--- a/main.py
+++ b/main.py
@@ -12,9 +12,11 @@ from logging.config import dictConfig
 from datetime import datetime
 import hashlib
 import argparse
+import sys
 import requests
 from requests.exceptions import HTTPError
 import os
+from apis import HEADERS
 from apis.modrinth_api import ModrinthAPI
 
 # Program setup:
@@ -64,13 +66,12 @@ args = parser.parse_args()
 
 # Make sure the log directory exists before configuring file logging.
 # Create the directory and any necessary parent directories if they don't exist.
-if not os.path.exists(args.log_dir):
-    os.makedirs(args.log_dir)
+os.makedirs(args.log_dir, exist_ok=True)
 
 # Configure logging:
 # - console output is short and readable
 # - file output is more detailed and rotated to avoid huge log files
-logging.config.dictConfig({
+dictConfig({
     'version': 1,
     'formatters': {
         # Brief formatter for console: just level and message
@@ -139,19 +140,23 @@ def get_sha1(
     return sha1.hexdigest()
 
 
-def download_file(url, path='./') -> str:
+def download_file(url, path='./', filename=None) -> str:
     """Downloads the file in chunks to handle large files efficiently.
 
     :param url: URL of the file to download
     :type url: str
     :param path: Directory path where the file will be saved (default: current directory)
     :type path: str
+    :param filename: Name to save the file as. If not given, it is derived
+        from the last segment of the URL.
+    :type filename: str | None
     :return: Name of the downloaded file
     :rtype: str
     """
-    filename = url.split('/')[-1]
+    if filename is None:
+        filename = url.split('/')[-1]
     logger.info(f'Downloading {filename}')
-    with requests.get(url, stream=True) as r:
+    with requests.get(url, stream=True, headers=HEADERS, timeout=60) as r:
         r.raise_for_status()
         with open(os.path.join(path, filename), 'wb') as f:
             for chunk in r.iter_content(chunk_size=8192):
@@ -174,7 +179,7 @@ def main():
     # Stop early if the mods directory doesn't exist.
     if not os.path.isdir(mod_dir):
         logger.critical('Mod folder does not exist')
-        exit()
+        sys.exit(1)
 
     # Create the API wrapper used for Modrinth lookups.
     modrinth = ModrinthAPI()
@@ -200,7 +205,7 @@ def main():
     # If there are no mods, there is nothing to update.
     if not mod_hash_list:
         logger.warning('No mods found!')
-        exit()
+        sys.exit(0)
 
     # Ask Modrinth which mods match the local hashes.
     # This retrieves metadata for all installed mods in a single API call
@@ -208,7 +213,7 @@ def main():
     if 'error' in mods_info_dict.keys():
         logger.critical(f'No updates can be performed quitting, '
                         f'error output:\n{mods_info_dict["error"]}')
-        exit()
+        sys.exit(1)
     logger.debug(f'Bulk mods info: {mods_info_dict}')
 
     # Group mods by loader because update queries are loader-specific.
@@ -233,7 +238,7 @@ def main():
         if 'error' in mods_update_info[loader].keys():
             logger.critical(f'No updates can be performed quitting, '
                             f'error output:\n{mods_update_info[loader]["error"]}')
-            exit()
+            sys.exit(1)
     logger.debug(f'Mods update info: {mods_update_info}')
 
     mods_updated_count = 0
@@ -255,34 +260,41 @@ def main():
             no_new_version_count += 1
             continue
 
-        # Extract download information from the update data
+        # Extract download information from the update data.
+        # Modrinth marks the canonical jar with 'primary'; fall back to the
+        # first file if none is marked.
         mod_update_files = mods_update_info[mods_loader_dict[mod]][mod]['files']
-        mod_dl_url = mod_update_files[0]['url']
-        new_mod_filename = mod_update_files[0]['filename']
+        mod_update_file = next(
+            (file for file in mod_update_files if file.get('primary')),
+            mod_update_files[0])
+        mod_dl_url = mod_update_file['url']
+        new_mod_filename = mod_update_file['filename']
 
         # If the SHA-1 already matches, the mod is already up to date.
-        if mod == mod_update_files[0]['hashes']['sha1']:
+        if mod == mod_update_file['hashes']['sha1']:
             logger.info(f'Skipping {mods_filename_dict[mod]} is already updated')
             continue
 
         logger.debug(f'Update link for {mods_filename_dict[mod]}: '
-                     f'{mod_update_files[0]["url"]}')
+                     f'{mod_dl_url}')
         logger.info(f'Updating {mods_filename_dict[mod]} to {new_mod_filename}')
 
         try:
-            # Download the updated mod file.
-            download_file(mod_dl_url, mod_dir)
+            # Download the updated mod file under the API-provided filename.
+            download_file(mod_dl_url, mod_dir, filename=new_mod_filename)
 
             # Optionally, delete the old file after the new one is downloaded.
-            # Controlled by the --keep flag
-            if not args.keep:
+            # Controlled by the --keep flag. Skipped when the new file kept the
+            # same name, since removing it would delete the fresh download.
+            if not args.keep and new_mod_filename != mods_filename_dict[mod]:
                 os.remove(os.path.join(mod_dir, mods_filename_dict[mod]))
                 logger.info(f'Deleted old mod file: {mods_filename_dict[mod]}')
         except HTTPError as err:
             logger.error(f'HTTP error occurred: {err}')
+            continue
         except Exception as err:
             logger.critical(f'Unexpected error occurred: {err}')
-            exit()
+            sys.exit(1)
 
         mods_updated_count += 1
 

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -1,0 +1,156 @@
+"""Tests for the apis package (BaseModApiClient and ModrinthAPI)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from requests.exceptions import HTTPError, ConnectionError, Timeout
+
+from apis.base import BaseModApiClient, DEFAULT_TIMEOUT
+from apis.modrinth_api import ModrinthAPI, MODRINTH_API_URL
+
+
+def make_client(base_url='https://api.example.com/v2'):
+    return BaseModApiClient(base_url)
+
+
+class TestBaseModApiClientInit:
+    def test_appends_trailing_slash(self):
+        client = make_client('https://api.example.com/v2')
+        assert client.base_url == 'https://api.example.com/v2/'
+
+    def test_keeps_existing_trailing_slash(self):
+        client = make_client('https://api.example.com/v2/')
+        assert client.base_url == 'https://api.example.com/v2/'
+
+    @pytest.mark.parametrize('bad_url', [
+        'not-a-url',
+        'ftp://example.com',
+        'example.com',
+        'https://nodot',
+    ])
+    def test_rejects_invalid_url(self, bad_url):
+        with pytest.raises(ValueError):
+            BaseModApiClient(bad_url)
+
+    def test_uses_default_headers_when_none_given(self):
+        from apis import HEADERS
+        client = make_client()
+        assert client.headers == HEADERS
+
+    def test_uses_custom_headers(self):
+        headers = {'User-agent': 'test-agent'}
+        client = BaseModApiClient('https://api.example.com', headers=headers)
+        assert client.headers == headers
+
+
+class TestMakePostRequest:
+    def _mock_response(self, json_data=None):
+        response = MagicMock()
+        response.json.return_value = json_data if json_data is not None else {}
+        response.status_code = 200
+        return response
+
+    def test_builds_url_without_double_slash(self):
+        client = make_client()
+        response = self._mock_response({'ok': True})
+        with patch.object(client._session, 'post',
+                          return_value=response) as mock_post:
+            result = client._make_post_request('version_files', {'a': 1})
+        called_url = mock_post.call_args[0][0]
+        assert called_url == 'https://api.example.com/v2/version_files'
+        assert '//version_files' not in called_url
+        assert result == {'ok': True}
+
+    def test_strips_leading_slash_from_method(self):
+        client = make_client()
+        response = self._mock_response()
+        with patch.object(client._session, 'post',
+                          return_value=response) as mock_post:
+            client._make_post_request('/version_files', {})
+        assert mock_post.call_args[0][0] == \
+            'https://api.example.com/v2/version_files'
+
+    def test_sets_default_timeout(self):
+        client = make_client()
+        response = self._mock_response()
+        with patch.object(client._session, 'post',
+                          return_value=response) as mock_post:
+            client._make_post_request('version_files', {})
+        assert mock_post.call_args[1]['timeout'] == DEFAULT_TIMEOUT
+
+    def test_custom_timeout_not_overridden(self):
+        client = make_client()
+        response = self._mock_response()
+        with patch.object(client._session, 'post',
+                          return_value=response) as mock_post:
+            client._make_post_request('version_files', {}, timeout=5)
+        assert mock_post.call_args[1]['timeout'] == 5
+
+    def test_sends_body_as_json_with_headers(self):
+        client = make_client()
+        response = self._mock_response()
+        body = {'hashes': ['abc'], 'algorithm': 'sha1'}
+        with patch.object(client._session, 'post',
+                          return_value=response) as mock_post:
+            client._make_post_request('version_files', body)
+        assert mock_post.call_args[1]['json'] == body
+        assert mock_post.call_args[1]['headers'] == client.headers
+
+    @pytest.mark.parametrize('exception', [
+        HTTPError('boom'),
+        ConnectionError('boom'),
+        Timeout('boom'),
+        requests.RequestException('boom'),
+    ])
+    def test_returns_error_dict_on_request_failure(self, exception):
+        client = make_client()
+        with patch.object(client._session, 'post', side_effect=exception):
+            result = client._make_post_request('version_files', {})
+        assert 'error' in result
+
+    def test_http_error_from_status_returns_error_dict(self):
+        client = make_client()
+        response = MagicMock()
+        response.raise_for_status.side_effect = HTTPError('404')
+        with patch.object(client._session, 'post', return_value=response):
+            result = client._make_post_request('version_files', {})
+        assert 'error' in result
+
+
+class TestModrinthAPI:
+    def test_default_base_url(self):
+        api = ModrinthAPI()
+        assert api.base_url == MODRINTH_API_URL + '/'
+
+    def test_default_hash_type(self):
+        api = ModrinthAPI()
+        assert api.hash_type == 'sha1'
+
+    def test_get_mods_by_hash_body(self):
+        api = ModrinthAPI()
+        with patch.object(api, '_make_post_request',
+                          return_value={}) as mock_request:
+            api.get_mods_by_hash(['hash1', 'hash2'])
+        mock_request.assert_called_once_with(
+            'version_files',
+            {'hashes': ['hash1', 'hash2'], 'algorithm': 'sha1'})
+
+    def test_get_mod_updates_by_hash_body(self):
+        api = ModrinthAPI()
+        with patch.object(api, '_make_post_request',
+                          return_value={}) as mock_request:
+            api.get_mod_updates_by_hash(
+                ['hash1'], game_version='1.21', loader='fabric')
+        mock_request.assert_called_once_with(
+            'version_files/update',
+            {'hashes': ['hash1'],
+             'algorithm': 'sha1',
+             'loaders': ['fabric'],
+             'game_versions': ['1.21']})
+
+    def test_error_response_passthrough(self):
+        api = ModrinthAPI()
+        error = {'error': 'HTTP error occurred: 404'}
+        with patch.object(api, '_make_post_request', return_value=error):
+            assert api.get_mods_by_hash(['hash1']) == error


### PR DESCRIPTION
Bug fixes:
- Don't count failed downloads as successful updates (missing continue
  after HTTPError)
- Don't delete the freshly downloaded file when the update keeps the
  same filename as the old mod
- Remove double slash in request URLs built by BaseModApiClient
- Restore Python 3.9 compatibility (PEP 604 annotations crashed at
  import time) via `from __future__ import annotations`

Hardening:
- download_file now sends the project User-Agent, uses a 60s timeout,
  and saves under the API-provided filename instead of parsing the URL
- Prefer the file marked `primary` by Modrinth over files[0]
- Exit with status 1 on fatal errors (exit() always returned 0)
- Raise ValueError instead of bare Exception for invalid base URLs
- Use module-named loggers instead of a logger literally named 'root'

Other:
- Add pytest suite for the apis package (CI's pytest step previously
  failed with exit code 5 because no tests existed)
- Correct README usage instructions (script name and flags were wrong)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012KkA5C1XbLXTAWnf7YveQ7